### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -6,7 +6,7 @@ use Text::Emotion::Scorer;
 
 {
     my $scorer = Text::Emotion::Scorer.new;
-    isa_ok $scorer, Text::Emotion::Scorer;
+    isa-ok $scorer, Text::Emotion::Scorer;
 }
 
 done;


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants.  The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.